### PR TITLE
RPCh/sdk update and use of singleton for SDK instance

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -32,7 +32,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.27.19",
     "@metamask/eth-sig-util": "^6.0.1",
     "@rollup/plugin-replace": "^5.0.2",
-    "@rpch/sdk": "1.2.4",
+    "@rpch/sdk": "^1.6.0",
     "@types/chrome": "^0.0.245",
     "@types/events": "^3.0.0",
     "@types/less": "^3.0.4",

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@enkryptcom/types": "workspace:^",
-    "@rpch/sdk": "1.2.4",
+    "@rpch/sdk": "^1.6.0",
     "eventemitter3": "^5.0.1",
     "isomorphic-ws": "^5.0.0",
     "json-rpc-2.0": "^1.6.0",

--- a/packages/request/src/libs/RPChClient.ts
+++ b/packages/request/src/libs/RPChClient.ts
@@ -1,36 +1,55 @@
 import RPChSDK, { JRPC, type Ops } from "@rpch/sdk";
 import { JSONRPCParams } from "json-rpc-2.0";
 
+class RPChSDKSingleton {
+  static sdk: RPChSDK | undefined;
+
+  static options: Ops = {
+    discoveryPlatformEndpoint:
+      process.env.VUE_APP_DISCOVERY_PLATFORM_API_ENDPOINT || undefined,
+    forceZeroHop: true,
+  };
+
+  static send(
+    ...args: Parameters<RPChSDK["send"]>
+  ): ReturnType<RPChSDK["send"]> {
+    if (!this.sdk) {
+      // TODO: Remove after confirmation and testing
+      console.log(
+        "RPCh: CREATING SDK INSTANCE with OPS ",
+        RPChSDKSingleton.options
+      );
+      console.log("RPCh: Client ID ", process.env.RPCH_SECRET_TOKEN);
+
+      if (!process.env.RPCH_SECRET_TOKEN) {
+        console.error("MISSING RPCH SECRET TOKEN");
+        throw new Error("MISSING RPCH SECRET TOKEN");
+      }
+
+      console.info("RPCh: first SEND request, creating SDK instance");
+      this.sdk = new RPChSDK(process.env.RPCH_SECRET_TOKEN, this.options);
+    }
+    return this.sdk.send(...args);
+  }
+}
+
 export class RPChClient {
-  sdk: RPChSDK;
+  rpcUrl: string;
 
-  constructor(provider: string) {
-    const ops: Ops = {
-      discoveryPlatformEndpoint: process.env.DISCOVERY_PLATFORM_API_ENDPOINT,
-      provider,
-    };
-
-    // TODO: Remove after confirmation and testing
-    console.log("RPCh: CREATING SDK INSTANCE with OPS ", ops);
-    console.log("RPCh: Client ID ", process.env.RPCH_SECRET_TOKEN);
-
-    this.sdk = new RPChSDK(process.env.RPCH_SECRET_TOKEN, ops);
+  constructor(rpcUrl: string) {
+    this.rpcUrl = rpcUrl;
   }
 
   request(method: string, params: JSONRPCParams): Promise<unknown> {
     // TODO: Remove after confirmation and testing
-    console.log(
-      "RPCh: SENDING REQUEST to: ",
-      (this.sdk as any & RPChSDK).ops.provider
-    );
+    console.log("RPCh: SENDING REQUEST to: ", this.rpcUrl);
     console.log("RPCh: SENDING REQUEST method: ", method, " params: ", params);
 
-    return this.sdk
-      .send({
-        jsonrpc: "2.0",
-        method,
-        params,
-      })
+    return RPChSDKSingleton.send({
+      jsonrpc: "2.0",
+      method,
+      params,
+    })
       .then((res) => res.json())
       .then(({ result }: JRPC.Result) => result);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2460,7 +2460,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^15.2.1
     "@rollup/plugin-replace": ^5.0.2
     "@rollup/plugin-typescript": ^11.1.3
-    "@rpch/sdk": 1.2.4
+    "@rpch/sdk": ^1.6.0
     "@types/chrome": ^0.0.245
     "@types/ethereumjs-abi": ^0.6.3
     "@types/events": ^3.0.0
@@ -2651,7 +2651,7 @@ __metadata:
   resolution: "@enkryptcom/request@workspace:packages/request"
   dependencies:
     "@enkryptcom/types": "workspace:^"
-    "@rpch/sdk": 1.2.4
+    "@rpch/sdk": ^1.6.0
     "@types/chai": ^4.3.6
     "@types/mocha": ^10.0.1
     "@types/node": ^20.6.0
@@ -5999,28 +5999,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rpch/compat-crypto@npm:*":
-  version: 0.5.3
-  resolution: "@rpch/compat-crypto@npm:0.5.3"
+"@rpch/compat-crypto@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@rpch/compat-crypto@npm:0.8.0"
   dependencies:
     "@noble/ciphers": ^0.4.0
     "@noble/curves": ^1.2.0
     "@noble/hashes": ^1.3.2
-  checksum: 8dc9d3b6e4d2dbf29742b742a28d1ca957d54eb01d747961ab926015d662f962a3ef60cf123f7684c721a69df6aaab096c9062e8bad2dd8b148e3573977685cc
+  checksum: 326040aee188bd7d442e4d009591dbd789e635c74c13408f1f74035a4e2d181b4304ecfad4ff7d4c4a3041ffff6d6c5c3bc8ee17443ef10e29a7472013ed5176
   languageName: node
   linkType: hard
 
-"@rpch/sdk@npm:1.2.4":
-  version: 1.2.4
-  resolution: "@rpch/sdk@npm:1.2.4"
+"@rpch/sdk@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@rpch/sdk@npm:1.6.0"
   dependencies:
-    "@rpch/compat-crypto": "*"
+    "@rpch/compat-crypto": ^0.8.0
     async-retry: ^1.3.3
     debug: ^4.3.4
     ethers: ^5.7.2
     isomorphic-ws: ^5.0.0
     lz-string: ^1.5.0
-  checksum: 8b989f33d0287e70eaf68320494090ddaafdd0cac1791d82277b5a010cedd638cff746acf9847c0d17300467158264a29752f19cf42ca436f0baf4226ace1a25
+  checksum: 28c65843c1fa7b10da7133adcdaf9f55bba7c3726f2d0c8218d03e71b651e5b5cd5fdf9970bccbbba087b63ebe72362a0290555b085d8a65bae708d7fbe00d6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Done:
- version of `@RPC/sdk` updated to `^1.6.0`
- refactored usage of SDK instances to follow singleton pattern - single instance across the app

Test steps are the same as in the previous PR - https://github.com/Rpc-h/wallet-enKrypt/pull/2

Observations:
- The Request package works like a charm.
- Enkrypt UI have a problem with the `a.randomUUID is not a function` error

![image](https://github.com/Rpc-h/wallet-enKrypt/assets/9512544/ac861a7f-6be9-44cd-a704-0d4ee785d1a6)
